### PR TITLE
Update index.md

### DIFF
--- a/src-docs/docs/index.md
+++ b/src-docs/docs/index.md
@@ -35,7 +35,7 @@ This *OCA* exporter will export the most common features of all drawing/animatio
 - [Installation](install.md)
 - [Use layer tags](layer-tags.md)
 - [List of supported blending modes](blending-modes.md)
-- [Settings](settigns.md)
+- [Settings](settings.md)
 
 ## License
 


### PR DESCRIPTION
Hi. I was going through the OCA for Krita docs.
https://oca-krita.rxlab.guide/

The Table of Contents link for the "Settings" entry currently points to a broken webpage link of: https://oca-krita.rxlab.guide/settigns.md

It appears like that URL should point to the webpage: https://oca-krita.rxlab.guide/settings